### PR TITLE
Fix TelemetrySensor setup and relax intervals

### DIFF
--- a/src/airtime.h
+++ b/src/airtime.h
@@ -67,9 +67,9 @@ class AirTime : private concurrency::OSThread
     uint8_t lastUtilPeriod = 0;
     uint8_t lastUtilPeriodTX = 0;
     uint32_t secSinceBoot = 0;
-    uint8_t max_channel_util_percent = 40;
-    uint8_t polite_channel_util_percent = 25;
-    uint8_t polite_duty_cycle_percent = 50; // half of Duty Cycle allowance is ok for metadata
+    uint8_t max_channel_util_percent = 100;
+    uint8_t polite_channel_util_percent = 100;
+    uint8_t polite_duty_cycle_percent = 100;
 
     struct airtimeStruct {
         uint32_t periodTX[PERIODS_TO_LOG];     // AirTime transmitted

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -7,9 +7,9 @@
 #define THIRTY_SECONDS_MS 30 * 1000
 #define FIVE_SECONDS_MS 5 * 1000
 
-#define min_default_telemetry_interval_secs 30 * 60
+#define min_default_telemetry_interval_secs 1
 #define default_gps_update_interval IF_ROUTER(ONE_DAY, 2 * 60)
-#define default_telemetry_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 60 * 60)
+#define default_telemetry_broadcast_interval_secs 1
 #define default_broadcast_interval_secs IF_ROUTER(ONE_DAY / 2, 15 * 60)
 #define default_wait_bluetooth_secs IF_ROUTER(1, 60)
 #define default_sds_secs IF_ROUTER(ONE_DAY, UINT32_MAX) // Default to forever super deep sleep

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -635,7 +635,7 @@ void NodeDB::installRoleDefaults(meshtastic_Config_DeviceConfig_Role role)
         config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_CORE_PORTNUMS_ONLY;
     } else if (role == meshtastic_Config_DeviceConfig_Role_SENSOR) {
         moduleConfig.telemetry.environment_measurement_enabled = true;
-        moduleConfig.telemetry.environment_update_interval = 300;
+        moduleConfig.telemetry.environment_update_interval = 1;
     } else if (role == meshtastic_Config_DeviceConfig_Role_LOST_AND_FOUND) {
         config.position.position_broadcast_smart_enabled = false;
         config.position.position_broadcast_secs = 300; // Every 5 minutes

--- a/src/modules/Telemetry/Sensor/TelemetrySensor.cpp
+++ b/src/modules/Telemetry/Sensor/TelemetrySensor.cpp
@@ -8,3 +8,7 @@
 #include "main.h"
 
 #endif
+
+#if !MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR
+void TelemetrySensor::setup() {}
+#endif


### PR DESCRIPTION
## Summary
- add a default implementation of `TelemetrySensor::setup`
- allow telemetry intervals of one second
- disable airtime restriction limits

## Testing
- `platformio test -e native` *(fails: pio not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663c9bf92c8329bbae815e9288554a